### PR TITLE
chore: add app id annotation

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -79,3 +79,26 @@ jobs:
               name: artifactName,
               data: await fs.readFile(artifactPathName)
             });
+
+  app-store-release:
+      runs-on: ubuntu-latest
+      needs: build
+      if: github.event_name == 'release'
+      steps:
+          - uses: actions/checkout@v3
+            with:
+                submodules: true
+          - name: Download plugin-feed jar
+            uses: actions/download-artifact@v2
+            with:
+                name: plugin-feed
+                path: build/libs
+          - name: Sync to Halo App Store
+            uses: halo-sigs/app-store-release-action@main
+            with:
+                github-token: ${{secrets.GITHUB_TOKEN}}
+                app-id: ${{secrets.APP_ID}}
+                release-id: ${{ github.event.release.id }}
+                assets-dir: "build/libs"
+                halo-username: ${{ secrets.HALO_USERNAME }}
+                halo-password: ${{ secrets.HALO_PASSWORD }}

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -1,11 +1,13 @@
 apiVersion: plugin.halo.run/v1alpha1
 kind: Plugin
 metadata:
-  # The name defines how the plugin is invoked,A unique name
   name: PluginFeed
+  annotations:
+    # Add supports for Halo App Store
+    # https://halo.run/store/apps/app-KhIVw
+    "store.halo.run/app-id": "app-KhIVw"
 spec:
   enabled: true
-  # 'version' is a valid semantic version string (see semver.org).
   version: 1.1.1
   requires: ">=2.4.0"
   author:
@@ -14,7 +16,6 @@ spec:
   logo: https://halo.run/logo
   settingName: plugin-feed-setting
   configMapName: plugin-feed-config
-  # 'homepage' usually links to the GitHub repository of the plugin
   homepage: https://github.com/halo-sigs/plugin-feed
   displayName: "RSS"
   description: "为站点生成 RSS 订阅链接"


### PR DESCRIPTION
1. 添加应用市场 ID 的 annotation，方便在首次初始化 Halo 之后可以在应用市场检测后续的更新。
2. 添加发布到应用市场的 CI 步骤。

/kind improvement

```release-note
添加应用市场的 App ID 字段，使其可以在内置的应用市场检测新版本。
```